### PR TITLE
[WIP] Adding assertion capability on the incoming request message

### DIFF
--- a/Goldlight.HttpClientTestSupport/Goldlight.HttpClientTestSupport.csproj
+++ b/Goldlight.HttpClientTestSupport/Goldlight.HttpClientTestSupport.csproj
@@ -13,6 +13,7 @@
     <AssemblyVersion>1.1.0.0</AssemblyVersion>
     <FileVersion>1.1.0.0</FileVersion>
     <PackageVersion>1.1.0.0</PackageVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Goldlight.HttpClientTestSupport/HttpRequestAssertionException.cs
+++ b/Goldlight.HttpClientTestSupport/HttpRequestAssertionException.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Goldlight.HttpClientTestSupport
+{
+  public class HttpRequestAssertionException : Exception
+  {
+
+  }
+}

--- a/Goldlight.HttpClientTestSupportTests/ExampleControllerHandlingTests.cs
+++ b/Goldlight.HttpClientTestSupportTests/ExampleControllerHandlingTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -36,7 +36,7 @@ namespace Goldlight.HttpClientTestSupportTests
     [Fact]
     public async Task GivenMultipleInputsIntoController_WhenProcessing_ThenModelIsReturned()
     {
-      List<SampleModel> sample = new List<SampleModel>() {new SampleModel(), new SampleModel()};
+      List<SampleModel> sample = new List<SampleModel>() { new SampleModel(), new SampleModel() };
       FakeHttpMessageHandler fake = new FakeHttpMessageHandler().WithStatusCode(HttpStatusCode.OK)
         .WithResponseHeader("order66", "babyyoda").WithExpectedContent(sample);
       HttpClient httpClient = new HttpClient(fake);
@@ -87,6 +87,18 @@ namespace Goldlight.HttpClientTestSupportTests
       IEnumerable<SampleModel> output = await exampleController.GetAll();
       Assert.Equal(1, invocationCount);
       Assert.Equal(0, postInvocationCount);
+    }
+
+    [Fact]
+    public async Task GivenRequest_WhenProcessing_ThenRequestValidatorPerformed()
+    {
+      List<SampleModel> sample = new List<SampleModel>() { new SampleModel(), new SampleModel() };
+      FakeHttpMessageHandler fake = new FakeHttpMessageHandler()
+        .WithRequestValidator(request => request.Method == HttpMethod.Get)
+        .WithExpectedContent(sample);
+      HttpClient httpClient = new HttpClient(fake);
+      ExampleControllerHandling exampleController = new ExampleControllerHandling(httpClient);
+      await exampleController.GetAll();
     }
   }
 }

--- a/Goldlight.HttpClientTestSupportTests/FakeHttpMessageHandlerTests.cs
+++ b/Goldlight.HttpClientTestSupportTests/FakeHttpMessageHandlerTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using Goldlight.HttpClientTestSupport;
 using System.Net;
@@ -119,7 +119,7 @@ namespace Goldlight.HttpClientTestSupportTests
     public async Task GivenValidRequestWithMultiValueTrailingHeader_WhenPostIsCalled_ThenTrailingHeaderIsSet()
     {
       FakeHttpMessageHandler fake =
-        new FakeHttpMessageHandler().WithTrailingResponseHeader("custom", new[] {"value", "value2"});
+        new FakeHttpMessageHandler().WithTrailingResponseHeader("custom", new[] { "value", "value2" });
       HttpClient httpClient = new HttpClient(fake);
       HttpResponseMessage response = await httpClient.PostWrapperAsync("Content");
       Assert.Equal(2, response.TrailingHeaders.GetValues("custom").Count());
@@ -129,7 +129,7 @@ namespace Goldlight.HttpClientTestSupportTests
     public async Task GivenValidRequestWithMultiValueHeader_WhenPostIsCalled_ThenHeaderIsSet()
     {
       FakeHttpMessageHandler fake =
-        new FakeHttpMessageHandler().WithResponseHeader("custom", new[] {"value", "value2"});
+        new FakeHttpMessageHandler().WithResponseHeader("custom", new[] { "value", "value2" });
       HttpClient httpClient = new HttpClient(fake);
       HttpResponseMessage response = await httpClient.PostWrapperAsync("Content");
       Assert.Equal(2, response.Headers.GetValues("custom").Count());
@@ -142,6 +142,24 @@ namespace Goldlight.HttpClientTestSupportTests
       HttpClient httpClient = new HttpClient(fake);
       HttpResponseMessage response = await httpClient.PostWrapperAsync("MyContent");
       Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GivenInvalidRequest_WhenRequestValudatorPerformed_ExceptionThrown()
+    {
+      FakeHttpMessageHandler fake = new FakeHttpMessageHandler()
+        .WithRequestValidator(request => request.Headers.TryGetValues("Authorization", out var _));
+      HttpClient httpClient = new HttpClient(fake);
+      await Assert.ThrowsAsync<HttpRequestAssertionException>(() => httpClient.PostWrapperAsync("MyContent"));
+    }
+
+    [Fact]
+    public async Task GivenValidRequest_WhenRequestValudatorPerformed_NoExceptionThrows()
+    {
+      FakeHttpMessageHandler fake = new FakeHttpMessageHandler()
+        .WithRequestValidator(request => request.Method == HttpMethod.Post);
+      HttpClient httpClient = new HttpClient(fake);
+      HttpResponseMessage response = await httpClient.PostWrapperAsync("MyContent");
     }
   }
 }


### PR DESCRIPTION
At this point this is a higher-level design idea to enable asserting incoming request messages. As this is more like a 'show-case' it isn't production ready code and feel free to ditch it if you don't prefer it :)

Change:
A similar to preActions, there is preAssertions, only differ to use `Func<HttpRequestMessage, bool>`. Using bool as a return value otherwise we would need to somehow handle xunit/nunit/mstest/etc. assertion exceptions which require a dependency on those packages.
Hence using custom exception type. The catch all and return 500 block (`return new HttpResponseMessage(HttpStatusCode.InternalServerError);`) swallows the exceptions, code now filters out the the custom exception type, so it is left unhandled and the test case can become red when that is thrown.

