### PR TITLE
Adding an overload for request validator to accept custom assertion exceptions

### DIFF
--- a/Goldlight.HttpClientTestSupport/HttpRequestAssertionException.cs
+++ b/Goldlight.HttpClientTestSupport/HttpRequestAssertionException.cs
@@ -2,8 +2,25 @@
 
 namespace Goldlight.HttpClientTestSupport
 {
+  /// <summary>
+  /// Exception thrown when <see cref="FakeHttpMessageHandler.WithRequestValidator(Func{System.Net.Http.HttpRequestMessage, bool})"/> returns false.
+  /// </summary>
   public class HttpRequestAssertionException : Exception
   {
+    private const string AssertionMessage = "Request message validation returned failure.";
 
+    /// <summary>
+    /// Creates a new instance of <see cref="HttpRequestAssertionException"/>, with a custom error message.
+    /// </summary>
+    public HttpRequestAssertionException() : base(AssertionMessage)
+    {
+    }
+
+    /// <summary>
+    /// Creates a new instance of <see cref="HttpRequestAssertionException"/>, with a custom error message.
+    /// </summary>
+    public HttpRequestAssertionException(Exception exception) : base(AssertionMessage, exception)
+    {
+    }
   }
 }

--- a/Goldlight.HttpClientTestSupportTests/ExampleControllerHandling.cs
+++ b/Goldlight.HttpClientTestSupportTests/ExampleControllerHandling.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 

--- a/Goldlight.HttpClientTestSupportTests/ExampleControllerHandlingTests.cs
+++ b/Goldlight.HttpClientTestSupportTests/ExampleControllerHandlingTests.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Goldlight.HttpClientTestSupport;
 using Xunit;
+using Xunit.Sdk;
 
 namespace Goldlight.HttpClientTestSupportTests
 {
@@ -95,6 +96,82 @@ namespace Goldlight.HttpClientTestSupportTests
       List<SampleModel> sample = new List<SampleModel>() { new SampleModel(), new SampleModel() };
       FakeHttpMessageHandler fake = new FakeHttpMessageHandler()
         .WithRequestValidator(request => request.Method == HttpMethod.Get)
+        .WithExpectedContent(sample);
+      HttpClient httpClient = new HttpClient(fake);
+      ExampleControllerHandling exampleController = new ExampleControllerHandling(httpClient);
+      await exampleController.GetAll();
+    }
+
+    [Fact]
+    public async Task GivenRequest_WhenProcessing_ThenRequestValidatorHandlesCustomAssertionException()
+    {
+      List<SampleModel> sample = new List<SampleModel>() { new SampleModel(), new SampleModel() };
+      FakeHttpMessageHandler fake = new FakeHttpMessageHandler()
+        .WithRequestValidator<XunitException>(request => Assert.Equal(HttpMethod.Get, request.Method))
+        .WithExpectedContent(sample);
+      HttpClient httpClient = new HttpClient(fake);
+      ExampleControllerHandling exampleController = new ExampleControllerHandling(httpClient);
+      await exampleController.GetAll();
+    }
+
+    [Fact]
+    public async Task GivenRequest_WhenProcessing_ThenRequestValidatorHandlesCustomAssertionExceptionOrReturnValue()
+    {
+      List<SampleModel> sample = new List<SampleModel>() { new SampleModel(), new SampleModel() };
+      FakeHttpMessageHandler fake = new FakeHttpMessageHandler()
+        .WithRequestValidator<XunitException>(request =>
+        {
+          Assert.Equal(HttpMethod.Get, request.Method);
+          return true;
+        })
+        .WithExpectedContent(sample);
+      HttpClient httpClient = new HttpClient(fake);
+      ExampleControllerHandling exampleController = new ExampleControllerHandling(httpClient);
+      await exampleController.GetAll();
+    }
+
+    [Fact]
+    public async Task GivenRequest_WhenProcessingAsync_ThenRequestValidatorReturnValue()
+    {
+      List<SampleModel> sample = new List<SampleModel>() { new SampleModel(), new SampleModel() };
+      FakeHttpMessageHandler fake = new FakeHttpMessageHandler()
+        .WithRequestValidatorAsync(async request =>
+        {
+          var content = await request.Content.ReadAsStringAsync();
+          return content == null;
+        })
+        .WithExpectedContent(sample);
+      HttpClient httpClient = new HttpClient(fake);
+      ExampleControllerHandling exampleController = new ExampleControllerHandling(httpClient);
+      await exampleController.GetAll();
+    }
+
+    [Fact]
+    public async Task GivenRequest_WhenProcessingAsync_ThenRequestValidatorHandlesCustomAssertionExceptionOrReturnValue()
+    {
+      List<SampleModel> sample = new List<SampleModel>() { new SampleModel(), new SampleModel() };
+      FakeHttpMessageHandler fake = new FakeHttpMessageHandler()
+        .WithRequestValidatorAsync<XunitException>(async request =>
+        {
+          var content = await request.Content.ReadAsStringAsync();
+          return content == null;
+        })
+        .WithExpectedContent(sample);
+      HttpClient httpClient = new HttpClient(fake);
+      ExampleControllerHandling exampleController = new ExampleControllerHandling(httpClient);
+      await exampleController.GetAll();
+    }
+
+    [Fact]
+    public async Task GivenRequest_WhenProcessingAsync_ThenRequestValidatorHandlesCustomAssertionException()
+    {
+      List<SampleModel> sample = new List<SampleModel>() { new SampleModel(), new SampleModel() };
+      FakeHttpMessageHandler fake = new FakeHttpMessageHandler()
+        .WithRequestValidatorAsync<XunitException>(async request =>
+        {
+          var content = await request.Content.ReadAsStringAsync();
+          Assert.Null(content);
+        })
         .WithExpectedContent(sample);
       HttpClient httpClient = new HttpClient(fake);
       ExampleControllerHandling exampleController = new ExampleControllerHandling(httpClient);


### PR DESCRIPTION
The new overload has a generic type parameter. This type parameter can be any assertion library's exception type or even a custom exception type, that is thrown during validation. Such exceptions will not be handled as HTTP 500 (Internal Server Error) response, but as a validation error.

- Adding an overload for request validator to accept custom assertion exceptions
- Adding async overloads on validation, so content may be read with async-await, non-blocking fashion.
- Adding documentation
- Adding unit tests
- Adding ConfigureAwait(false) on awaits.