### PR TITLE
Handling Stream Content Response

### DIFF
--- a/Goldlight.HttpClientTestSupportTests/ExampleControllerHandlingTests.cs
+++ b/Goldlight.HttpClientTestSupportTests/ExampleControllerHandlingTests.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Text;
 using System.Threading.Tasks;
 using Goldlight.HttpClientTestSupport;
 using Xunit;
@@ -10,172 +12,193 @@ using Xunit.Sdk;
 
 namespace Goldlight.HttpClientTestSupportTests
 {
-  public class ExampleControllerHandlingTests
-  {
-    [Fact]
-    public async Task GivenComplexController_WhenBadRequestIsExpected_ThenBadRequestIsHandled()
+    public class ExampleControllerHandlingTests
     {
-      FakeHttpMessageHandler fake = new FakeHttpMessageHandler().WithStatusCode(HttpStatusCode.BadRequest);
-      HttpClient httpClient = new HttpClient(fake);
-      ExampleControllerHandling exampleController = new ExampleControllerHandling(httpClient);
-      int called = 0;
-      try
-      {
-        await exampleController.GetById(Guid.NewGuid());
-      }
-      catch (Exception e)
-      {
-        if (e.Message.StartsWith("Unable to find "))
+        [Fact]
+        public async Task GivenComplexController_WhenBadRequestIsExpected_ThenBadRequestIsHandled()
         {
-          called++;
+            FakeHttpMessageHandler fake = new FakeHttpMessageHandler().WithStatusCode(HttpStatusCode.BadRequest);
+            HttpClient httpClient = new HttpClient(fake);
+            ExampleControllerHandling exampleController = new ExampleControllerHandling(httpClient);
+            int called = 0;
+            try
+            {
+                await exampleController.GetById(Guid.NewGuid());
+            }
+            catch (Exception e)
+            {
+                if (e.Message.StartsWith("Unable to find "))
+                {
+                    called++;
+                }
+            }
+
+            Assert.Equal(1, called);
         }
-      }
 
-      Assert.Equal(1, called);
-    }
-
-    [Fact]
-    public async Task GivenMultipleInputsIntoController_WhenProcessing_ThenModelIsReturned()
-    {
-      List<SampleModel> sample = new List<SampleModel>() { new SampleModel(), new SampleModel() };
-      FakeHttpMessageHandler fake = new FakeHttpMessageHandler().WithStatusCode(HttpStatusCode.OK)
-        .WithResponseHeader("order66", "babyyoda").WithExpectedContent(sample);
-      HttpClient httpClient = new HttpClient(fake);
-      ExampleControllerHandling exampleController = new ExampleControllerHandling(httpClient);
-      IEnumerable<SampleModel> output = await exampleController.GetAll();
-      Assert.Equal(2, output.Count());
-    }
-
-    [Fact]
-    public async Task GivenPreActionForController_WhenProcessing_ThenActionIsPerformed()
-    {
-      int invocationCount = 0;
-      List<SampleModel> sample = new List<SampleModel>() { new SampleModel(), new SampleModel() };
-      FakeHttpMessageHandler fake = new FakeHttpMessageHandler().WithPreRequest(() => invocationCount++)
-        .WithExpectedContent(sample);
-      HttpClient httpClient = new HttpClient(fake);
-      ExampleControllerHandling exampleController = new ExampleControllerHandling(httpClient);
-      IEnumerable<SampleModel> output = await exampleController.GetAll();
-      Assert.Equal(1, invocationCount);
-    }
-
-    [Fact]
-    public async Task GivenPostActionForController_WhenProcessing_ThenActionIsPerformed()
-    {
-      int invocationCount = 0;
-      List<SampleModel> sample = new List<SampleModel>() { new SampleModel(), new SampleModel() };
-      FakeHttpMessageHandler fake = new FakeHttpMessageHandler().WithPostRequest(() => invocationCount++)
-        .WithExpectedContent(sample);
-      HttpClient httpClient = new HttpClient(fake);
-      ExampleControllerHandling exampleController = new ExampleControllerHandling(httpClient);
-      IEnumerable<SampleModel> output = await exampleController.GetAll();
-      await exampleController.GetAll();
-      Assert.Equal(2, invocationCount);
-    }
-
-    [Fact]
-    public async Task GivenPreAndPostActionForController_WhenProcessing_ThenActionIsPerformed()
-    {
-      int invocationCount = 0;
-      int postInvocationCount = 0;
-      List<SampleModel> sample = new List<SampleModel>() { new SampleModel(), new SampleModel() };
-      FakeHttpMessageHandler fake = new FakeHttpMessageHandler().WithPreRequest(() => invocationCount++)
-        .WithPreRequest(() => throw new Exception("Throwing deliberately"))
-        .WithPostRequest(() => postInvocationCount++)
-        .WithExpectedContent(sample);
-      HttpClient httpClient = new HttpClient(fake);
-      ExampleControllerHandling exampleController = new ExampleControllerHandling(httpClient);
-      IEnumerable<SampleModel> output = await exampleController.GetAll();
-      Assert.Equal(1, invocationCount);
-      Assert.Equal(0, postInvocationCount);
-    }
-
-    [Fact]
-    public async Task GivenRequest_WhenProcessing_ThenRequestValidatorPerformed()
-    {
-      List<SampleModel> sample = new List<SampleModel>() { new SampleModel(), new SampleModel() };
-      FakeHttpMessageHandler fake = new FakeHttpMessageHandler()
-        .WithRequestValidator(request => request.Method == HttpMethod.Get)
-        .WithExpectedContent(sample);
-      HttpClient httpClient = new HttpClient(fake);
-      ExampleControllerHandling exampleController = new ExampleControllerHandling(httpClient);
-      await exampleController.GetAll();
-    }
-
-    [Fact]
-    public async Task GivenRequest_WhenProcessing_ThenRequestValidatorHandlesCustomAssertionException()
-    {
-      List<SampleModel> sample = new List<SampleModel>() { new SampleModel(), new SampleModel() };
-      FakeHttpMessageHandler fake = new FakeHttpMessageHandler()
-        .WithRequestValidator<XunitException>(request => Assert.Equal(HttpMethod.Get, request.Method))
-        .WithExpectedContent(sample);
-      HttpClient httpClient = new HttpClient(fake);
-      ExampleControllerHandling exampleController = new ExampleControllerHandling(httpClient);
-      await exampleController.GetAll();
-    }
-
-    [Fact]
-    public async Task GivenRequest_WhenProcessing_ThenRequestValidatorHandlesCustomAssertionExceptionOrReturnValue()
-    {
-      List<SampleModel> sample = new List<SampleModel>() { new SampleModel(), new SampleModel() };
-      FakeHttpMessageHandler fake = new FakeHttpMessageHandler()
-        .WithRequestValidator<XunitException>(request =>
+        [Fact]
+        public async Task GivenMultipleInputsIntoController_WhenProcessing_ThenModelIsReturned()
         {
-          Assert.Equal(HttpMethod.Get, request.Method);
-          return true;
-        })
-        .WithExpectedContent(sample);
-      HttpClient httpClient = new HttpClient(fake);
-      ExampleControllerHandling exampleController = new ExampleControllerHandling(httpClient);
-      await exampleController.GetAll();
-    }
+            List<SampleModel> sample = new List<SampleModel>() { new SampleModel(), new SampleModel() };
+            FakeHttpMessageHandler fake = new FakeHttpMessageHandler().WithStatusCode(HttpStatusCode.OK)
+              .WithResponseHeader("order66", "babyyoda").WithExpectedContent(sample);
+            HttpClient httpClient = new HttpClient(fake);
+            ExampleControllerHandling exampleController = new ExampleControllerHandling(httpClient);
+            IEnumerable<SampleModel> output = await exampleController.GetAll();
+            Assert.Equal(2, output.Count());
+        }
 
-    [Fact]
-    public async Task GivenRequest_WhenProcessingAsync_ThenRequestValidatorReturnValue()
-    {
-      List<SampleModel> sample = new List<SampleModel>() { new SampleModel(), new SampleModel() };
-      FakeHttpMessageHandler fake = new FakeHttpMessageHandler()
-        .WithRequestValidatorAsync(async request =>
+        [Fact]
+        public async Task GivenPreActionForController_WhenProcessing_ThenActionIsPerformed()
         {
-          var content = await request.Content.ReadAsStringAsync();
-          return content == null;
-        })
-        .WithExpectedContent(sample);
-      HttpClient httpClient = new HttpClient(fake);
-      ExampleControllerHandling exampleController = new ExampleControllerHandling(httpClient);
-      await exampleController.GetAll();
-    }
+            int invocationCount = 0;
+            List<SampleModel> sample = new List<SampleModel>() { new SampleModel(), new SampleModel() };
+            FakeHttpMessageHandler fake = new FakeHttpMessageHandler().WithPreRequest(() => invocationCount++)
+              .WithExpectedContent(sample);
+            HttpClient httpClient = new HttpClient(fake);
+            ExampleControllerHandling exampleController = new ExampleControllerHandling(httpClient);
+            IEnumerable<SampleModel> output = await exampleController.GetAll();
+            Assert.Equal(1, invocationCount);
+        }
 
-    [Fact]
-    public async Task GivenRequest_WhenProcessingAsync_ThenRequestValidatorHandlesCustomAssertionExceptionOrReturnValue()
-    {
-      List<SampleModel> sample = new List<SampleModel>() { new SampleModel(), new SampleModel() };
-      FakeHttpMessageHandler fake = new FakeHttpMessageHandler()
-        .WithRequestValidatorAsync<XunitException>(async request =>
+        [Fact]
+        public async Task GivenPostActionForController_WhenProcessing_ThenActionIsPerformed()
         {
-          var content = await request.Content.ReadAsStringAsync();
-          return content == null;
-        })
-        .WithExpectedContent(sample);
-      HttpClient httpClient = new HttpClient(fake);
-      ExampleControllerHandling exampleController = new ExampleControllerHandling(httpClient);
-      await exampleController.GetAll();
-    }
+            int invocationCount = 0;
+            List<SampleModel> sample = new List<SampleModel>() { new SampleModel(), new SampleModel() };
+            FakeHttpMessageHandler fake = new FakeHttpMessageHandler().WithPostRequest(() => invocationCount++)
+              .WithExpectedContent(sample);
+            HttpClient httpClient = new HttpClient(fake);
+            ExampleControllerHandling exampleController = new ExampleControllerHandling(httpClient);
+            IEnumerable<SampleModel> output = await exampleController.GetAll();
+            await exampleController.GetAll();
+            Assert.Equal(2, invocationCount);
+        }
 
-    [Fact]
-    public async Task GivenRequest_WhenProcessingAsync_ThenRequestValidatorHandlesCustomAssertionException()
-    {
-      List<SampleModel> sample = new List<SampleModel>() { new SampleModel(), new SampleModel() };
-      FakeHttpMessageHandler fake = new FakeHttpMessageHandler()
-        .WithRequestValidatorAsync<XunitException>(async request =>
+        [Fact]
+        public async Task GivenPreAndPostActionForController_WhenProcessing_ThenActionIsPerformed()
         {
-          var content = await request.Content.ReadAsStringAsync();
-          Assert.Null(content);
-        })
-        .WithExpectedContent(sample);
-      HttpClient httpClient = new HttpClient(fake);
-      ExampleControllerHandling exampleController = new ExampleControllerHandling(httpClient);
-      await exampleController.GetAll();
+            int invocationCount = 0;
+            int postInvocationCount = 0;
+            List<SampleModel> sample = new List<SampleModel>() { new SampleModel(), new SampleModel() };
+            FakeHttpMessageHandler fake = new FakeHttpMessageHandler().WithPreRequest(() => invocationCount++)
+              .WithPreRequest(() => throw new Exception("Throwing deliberately"))
+              .WithPostRequest(() => postInvocationCount++)
+              .WithExpectedContent(sample);
+            HttpClient httpClient = new HttpClient(fake);
+            ExampleControllerHandling exampleController = new ExampleControllerHandling(httpClient);
+            IEnumerable<SampleModel> output = await exampleController.GetAll();
+            Assert.Equal(1, invocationCount);
+            Assert.Equal(0, postInvocationCount);
+        }
+
+        [Fact]
+        public async Task GivenRequest_WhenProcessing_ThenRequestValidatorPerformed()
+        {
+            List<SampleModel> sample = new List<SampleModel>() { new SampleModel(), new SampleModel() };
+            FakeHttpMessageHandler fake = new FakeHttpMessageHandler()
+              .WithRequestValidator(request => request.Method == HttpMethod.Get)
+              .WithExpectedContent(sample);
+            HttpClient httpClient = new HttpClient(fake);
+            ExampleControllerHandling exampleController = new ExampleControllerHandling(httpClient);
+            await exampleController.GetAll();
+        }
+
+        [Fact]
+        public async Task GivenRequest_WhenProcessing_ThenRequestValidatorHandlesCustomAssertionException()
+        {
+            List<SampleModel> sample = new List<SampleModel>() { new SampleModel(), new SampleModel() };
+            FakeHttpMessageHandler fake = new FakeHttpMessageHandler()
+              .WithRequestValidator<XunitException>(request => Assert.Equal(HttpMethod.Get, request.Method))
+              .WithExpectedContent(sample);
+            HttpClient httpClient = new HttpClient(fake);
+            ExampleControllerHandling exampleController = new ExampleControllerHandling(httpClient);
+            await exampleController.GetAll();
+        }
+
+        [Fact]
+        public async Task GivenRequest_WhenProcessing_ThenRequestValidatorHandlesCustomAssertionExceptionOrReturnValue()
+        {
+            List<SampleModel> sample = new List<SampleModel>() { new SampleModel(), new SampleModel() };
+            FakeHttpMessageHandler fake = new FakeHttpMessageHandler()
+              .WithRequestValidator<XunitException>(request =>
+              {
+                  Assert.Equal(HttpMethod.Get, request.Method);
+                  return true;
+              })
+              .WithExpectedContent(sample);
+            HttpClient httpClient = new HttpClient(fake);
+            ExampleControllerHandling exampleController = new ExampleControllerHandling(httpClient);
+            await exampleController.GetAll();
+        }
+
+        [Fact]
+        public async Task GivenRequest_WhenProcessingAsync_ThenRequestValidatorReturnValue()
+        {
+            List<SampleModel> sample = new List<SampleModel>() { new SampleModel(), new SampleModel() };
+            FakeHttpMessageHandler fake = new FakeHttpMessageHandler()
+              .WithRequestValidatorAsync(async request =>
+              {
+                  var content = await request.Content.ReadAsStringAsync();
+                  return content == null;
+              })
+              .WithExpectedContent(sample);
+            HttpClient httpClient = new HttpClient(fake);
+            ExampleControllerHandling exampleController = new ExampleControllerHandling(httpClient);
+            await exampleController.GetAll();
+        }
+
+        [Fact]
+        public async Task GivenRequest_WhenProcessingAsync_ThenRequestValidatorHandlesCustomAssertionExceptionOrReturnValue()
+        {
+            List<SampleModel> sample = new List<SampleModel>() { new SampleModel(), new SampleModel() };
+            FakeHttpMessageHandler fake = new FakeHttpMessageHandler()
+              .WithRequestValidatorAsync<XunitException>(async request =>
+              {
+                  var content = await request.Content.ReadAsStringAsync();
+                  return content == null;
+              })
+              .WithExpectedContent(sample);
+            HttpClient httpClient = new HttpClient(fake);
+            ExampleControllerHandling exampleController = new ExampleControllerHandling(httpClient);
+            await exampleController.GetAll();
+        }
+
+        [Fact]
+        public async Task GivenRequest_WhenProcessingAsync_ThenRequestValidatorHandlesCustomAssertionException()
+        {
+            List<SampleModel> sample = new List<SampleModel>() { new SampleModel(), new SampleModel() };
+            FakeHttpMessageHandler fake = new FakeHttpMessageHandler()
+              .WithRequestValidatorAsync<XunitException>(async request =>
+              {
+                  var content = await request.Content.ReadAsStringAsync();
+                  Assert.Null(content);
+              })
+              .WithExpectedContent(sample);
+            HttpClient httpClient = new HttpClient(fake);
+            ExampleControllerHandling exampleController = new ExampleControllerHandling(httpClient);
+            await exampleController.GetAll();
+        }
+
+        [Fact]
+        public async Task GivenRequest_WhenProcessingAsync_ReturnStreamContent()
+        {
+            FakeHttpMessageHandler fake = new FakeHttpMessageHandler()
+              .WithStatusCode(HttpStatusCode.OK)
+              .WithExpectedContent(GetStream("this is my data"));
+            HttpClient httpClient = new HttpClient(fake);
+            ExampleControllerHandling exampleController = new ExampleControllerHandling(httpClient);
+            await exampleController.GetAll();
+        }
+
+        private Stream GetStream(string json)
+        {
+            var memory = new MemoryStream();
+            using (var writer = new StreamWriter(memory, Encoding.UTF8, leaveOpen: true))
+            {
+                writer.Write(json);
+            }
+            return memory;
+        }
     }
-  }
 }

--- a/Goldlight.HttpClientTestSupportTests/FakeHttpMessageHandlerTests.cs
+++ b/Goldlight.HttpClientTestSupportTests/FakeHttpMessageHandlerTests.cs
@@ -1,16 +1,18 @@
 ﻿using System;
+using System.IO;
 using System.Linq;
-using Goldlight.HttpClientTestSupport;
 using System.Net;
 using System.Net.Http;
+using System.Text;
 using System.Threading.Tasks;
+using Goldlight.HttpClientTestSupport;
 using Newtonsoft.Json;
 using Xunit;
 using Xunit.Sdk;
 
 namespace Goldlight.HttpClientTestSupportTests
 {
-  public class FakeHttpMessageHandlerTests
+    public class FakeHttpMessageHandlerTests
   {
     [Fact]
     public async Task GivenValidRequestWithDefaultsOnly_WhenGetIsCalled_ThenStatusIsOK()
@@ -105,6 +107,48 @@ namespace Goldlight.HttpClientTestSupportTests
       HttpClient httpClient = new HttpClient(fake);
       HttpResponseMessage response = await httpClient.PostWrapperAsync(content);
       Assert.Equal(returnedContent, await response.RequestMessage.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task GivenStreamContent_WhenGetCalled_ThenContentReturned()
+    {
+        string content = "{\"content\":\"set\"}";
+        using var memory = new MemoryStream();
+        using (var writer = new StreamWriter(memory, Encoding.UTF8, leaveOpen: true))
+        {
+            writer.Write(content);
+        }
+        FakeHttpMessageHandler fake = new FakeHttpMessageHandler().WithExpectedContent(content);
+        HttpClient httpClient = new HttpClient(fake);
+        HttpResponseMessage response = await httpClient.GetAsync("http://localhost");
+        Assert.Equal(content, await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task GivenNullString_WhenGetCalled_ThenContentReturned()
+    {
+        FakeHttpMessageHandler fake = new FakeHttpMessageHandler().WithExpectedContent((string)null);
+        HttpClient httpClient = new HttpClient(fake);
+        HttpResponseMessage response = await httpClient.GetAsync("http://localhost");
+        Assert.Equal(string.Empty, await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task GivenNullStream_WhenGetCalled_ThenContentReturned()
+    {
+        FakeHttpMessageHandler fake = new FakeHttpMessageHandler().WithExpectedContent((Stream)null);
+        HttpClient httpClient = new HttpClient(fake);
+        HttpResponseMessage response = await httpClient.GetAsync("http://localhost");
+        Assert.Equal(string.Empty, await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task GivenNullObject_WhenGetCalled_ThenContentReturned()
+    {
+        FakeHttpMessageHandler fake = new FakeHttpMessageHandler().WithExpectedContent<Exception>(null);
+        HttpClient httpClient = new HttpClient(fake);
+        HttpResponseMessage response = await httpClient.GetAsync("http://localhost");
+        Assert.Equal(string.Empty, await response.Content.ReadAsStringAsync());
     }
 
     [Fact]

--- a/Goldlight.HttpClientTestSupportTests/Goldlight.HttpClientTestSupportTests.csproj
+++ b/Goldlight.HttpClientTestSupportTests/Goldlight.HttpClientTestSupportTests.csproj
@@ -1,19 +1,19 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
- Adding a new overload that handles Stream response content.
- Covering test use-case with unit tests.
- Updating nuget packages in test project to latest release and adding multi target framework coverage.
- This is a breaking change for the use case of `WithExpectedContent(null)` where previous compiler could use the string overload but now type needs to be specified.