### PR TITLE
Adding WithExpectedContent overload that has a serialization options parameter

### DIFF
--- a/Goldlight.HttpClientTestSupport/FakeHttpMessageHandler.cs
+++ b/Goldlight.HttpClientTestSupport/FakeHttpMessageHandler.cs
@@ -419,6 +419,18 @@ namespace Goldlight.HttpClientTestSupport
     }
 
     /// <summary>
+    /// Set the content that is expected in the response.
+    /// </summary>
+    /// <param name="content">The content to populate the response.</param>
+    /// <param name="options">Options for custom serialization of the content.</param>
+    public FakeHttpMessageHandler WithExpectedContent<T>(T content, JsonSerializerOptions options) where T : class
+    {
+      string converted = JsonSerializer.Serialize(content, options);
+      _content = converted;
+      return this;
+    }
+
+    /// <summary>
     /// Set the version details for the response.
     /// </summary>
     /// <param name="version">The populated version.</param>

--- a/Goldlight.HttpClientTestSupport/FakeHttpMessageHandler.cs
+++ b/Goldlight.HttpClientTestSupport/FakeHttpMessageHandler.cs
@@ -411,19 +411,8 @@ namespace Goldlight.HttpClientTestSupport
     /// Set the content that is expected in the response.
     /// </summary>
     /// <param name="content">The content to populate the response.</param>
-    public FakeHttpMessageHandler WithExpectedContent<T>(T content) where T : class
-    {
-      string converted = JsonSerializer.Serialize(content);
-      _content = converted;
-      return this;
-    }
-
-    /// <summary>
-    /// Set the content that is expected in the response.
-    /// </summary>
-    /// <param name="content">The content to populate the response.</param>
     /// <param name="options">Options for custom serialization of the content.</param>
-    public FakeHttpMessageHandler WithExpectedContent<T>(T content, JsonSerializerOptions options) where T : class
+    public FakeHttpMessageHandler WithExpectedContent<T>(T content, JsonSerializerOptions options = null) where T : class
     {
       string converted = JsonSerializer.Serialize(content, options);
       _content = converted;

--- a/Goldlight.HttpClientTestSupport/Goldlight.HttpClientTestSupport.csproj
+++ b/Goldlight.HttpClientTestSupport/Goldlight.HttpClientTestSupport.csproj
@@ -17,6 +17,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="5.0.2" />
+    <PackageReference Include="System.Text.Json" Version="6.0.3" />
   </ItemGroup>
 </Project>

--- a/Goldlight.HttpClientTestSupportTests/ExampleControllerHandlingTests.cs
+++ b/Goldlight.HttpClientTestSupportTests/ExampleControllerHandlingTests.cs
@@ -102,6 +102,20 @@ namespace Goldlight.HttpClientTestSupportTests
       await exampleController.GetAll();
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task GivenResponseWithSerializationOptions_WhenProcessing_ControllerIgnoresWhitespace(bool writeIndented)
+    {
+      SampleModel sample = new SampleModel();
+      FakeHttpMessageHandler fake = new FakeHttpMessageHandler()
+        .WithExpectedContent(sample, new System.Text.Json.JsonSerializerOptions() { WriteIndented = writeIndented })
+        .WithStatusCode(HttpStatusCode.OK);
+      HttpClient httpClient = new HttpClient(fake);
+      ExampleControllerHandling exampleController = new ExampleControllerHandling(httpClient);
+      await exampleController.GetById(Guid.NewGuid());
+    }
+
     [Fact]
     public async Task GivenRequest_WhenProcessing_ThenRequestValidatorHandlesCustomAssertionException()
     {

--- a/Goldlight.HttpClientTestSupportTests/FakeHttpMessageHandlerTests.cs
+++ b/Goldlight.HttpClientTestSupportTests/FakeHttpMessageHandlerTests.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Linq;
-using Goldlight.HttpClientTestSupport;
 using System.Net;
 using System.Net.Http;
+using System.Text.Json;
 using System.Threading.Tasks;
+using Goldlight.HttpClientTestSupport;
 using Newtonsoft.Json;
 using Xunit;
 using Xunit.Sdk;
@@ -30,6 +31,16 @@ namespace Goldlight.HttpClientTestSupportTests
       SampleModel converted =
         JsonConvert.DeserializeObject<SampleModel>(await responseMessage.Content.ReadAsStringAsync());
       Assert.Equal("Stan Lee", converted.FullName);
+    }
+
+    [Fact]
+    public async Task GivenExpectedContentWithSerializationOptions_WhenGetIsCalled_ThenContentIsSetToModel()
+    {
+      FakeHttpMessageHandler fake = new FakeHttpMessageHandler().WithExpectedContent(new SampleModel(), new JsonSerializerOptions() { IgnoreReadOnlyProperties = true });
+      HttpClient httpClient = new HttpClient(fake);
+      HttpResponseMessage responseMessage = await httpClient.GetAsync("https://dummyaddress.com/someapi");
+      string result = await responseMessage.Content.ReadAsStringAsync();
+      Assert.Equal("{}", result);
     }
 
     [Fact]

--- a/Goldlight.HttpClientTestSupportTests/FakeHttpMessageHandlerTests.cs
+++ b/Goldlight.HttpClientTestSupportTests/FakeHttpMessageHandlerTests.cs
@@ -34,13 +34,23 @@ namespace Goldlight.HttpClientTestSupportTests
     }
 
     [Fact]
-    public async Task GivenExpectedContentWithSerializationOptions_WhenGetIsCalled_ThenContentIsSetToModel()
+    public async Task GivenExpectedContentWithSerializationOptions_WhenGetIsCalled_SerializationOptionsUsed()
     {
       FakeHttpMessageHandler fake = new FakeHttpMessageHandler().WithExpectedContent(new SampleModel(), new JsonSerializerOptions() { IgnoreReadOnlyProperties = true });
       HttpClient httpClient = new HttpClient(fake);
       HttpResponseMessage responseMessage = await httpClient.GetAsync("https://dummyaddress.com/someapi");
       string result = await responseMessage.Content.ReadAsStringAsync();
       Assert.Equal("{}", result);
+    }
+
+    [Fact]
+    public async Task GivenExpectedContentWithoutSerializationOptions_WhenGetIsCalled_UsesDefaultSerializationOptions()
+    {
+        FakeHttpMessageHandler fake = new FakeHttpMessageHandler().WithExpectedContent(new SampleModel(), null);
+        HttpClient httpClient = new HttpClient(fake);
+        HttpResponseMessage responseMessage = await httpClient.GetAsync("https://dummyaddress.com/someapi");
+        string result = await responseMessage.Content.ReadAsStringAsync();
+        Assert.Equal(@"{""FirstName"":""Stan"",""LastName"":""Lee"",""FullName"":""Stan Lee""}", result);
     }
 
     [Fact]

--- a/Goldlight.HttpClientTestSupportTests/Goldlight.HttpClientTestSupportTests.csproj
+++ b/Goldlight.HttpClientTestSupportTests/Goldlight.HttpClientTestSupportTests.csproj
@@ -7,13 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
A user can set ExpectedContent with an object and a custom serialization options that is used to convert the input into response string.
Adding tests to cover new functionality.
Updating nuget packages.