### PR TITLE
Setting up CI/CD pipeline with GitHub actions

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,0 +1,25 @@
+name: CD
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v2
+    - name: Set VERSION variable from tag
+      run: echo "VERSION=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --configuration Release --no-restore -p:Version=${VERSION}
+    - name: Create package
+      run: dotnet pack --configuration Release --no-build --include-symbols -p:Version=${VERSION}
+    - name: Publish
+      run: dotnet nuget push **/bin/Release/*.nupkg --source https://api.nuget.org/v3/index.json --api-key $nuget_api_key --skip-duplicate
+      env:
+        nuget_api_key: ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,19 @@
+name: CI
+
+on: [push, workflow_dispatch]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v2
+    - name: Install dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore
+    - name: Test
+      run: dotnet test --no-restore --no-build

--- a/Goldlight.HttpClientTestSupportTests/Goldlight.HttpClientTestSupportTests.csproj
+++ b/Goldlight.HttpClientTestSupportTests/Goldlight.HttpClientTestSupportTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
- CI pipeline triggered by push/manually starting a build
- CD pipeline triggered by creating a release
- CD uses tags to set version for the library. ie tag: v1.2.3 will result 1.2.3 as a nuget version number
- CD uses a NUGET_API_KEY which should be configured in the repo settings as a secret to push package to nuget.org

(I was wondering if you could create a release/nuget pkg with yesterday's changes, but then I thought about just helping with automating the release - I had these github workflows already set up in another project, I thought I would share to get started)